### PR TITLE
Temporarily let source link go to tumblr?

### DIFF
--- a/sources.html
+++ b/sources.html
@@ -3,27 +3,4 @@ layout: page_default
 title: Transcript Sources
 ---
 
-<p>Any transcripts on this site not listed below were sourced from <a href="https://drive.google.com/drive/folders/0BzWtYJgwf5A9NU1Vd0pMTG9HcmM">the Rusty Quill's official transcript archive</a>. (Unless I let this page get out-of-date; please <a href="mailto:{{site.email}}">let me know</a> if something looks wrong!)</p>
-
-<div class="table-of-contents source-index">
-{% for source in site.data.sources %}
-  <h3 class="ep-transcriber">
-  {%- if source.url -%}
-    <a target="_blank" href="{{source.url}}" name="{{source.name}}">{{source.name}}</a>:
-  {%- else -%}
-    <a name="{{source.name}}">{{source.name}}</a>:
-  {%- endif -%}
-  </h3>
-
-  <ul>
-  {%- for episode in source.episodes %}
-    <li>
-      <div class="ep-left"><a class="ep-title" href="{%if episode.path%}{{episode.path | prepend: site.baseurl}}{%else%}episode/{{episode.number}}.html{%endif%}">{{episode.number}} {{episode.title}}</a></div>
-    {%- if episode.url %}
-      <div class="ep-right"><a class="ep-source" target="_blank" href="{{episode.url}}">Source</a></div>
-    {%- endif %}
-    </li>
-  {%- endfor %}
-  </ul>
-{%- endfor %}
-</div>
+<p>All transcripts on this site were sourced from <a href="https://stellarscripts.tumblr.com/transcripts/">stellarscripts</a> on tumblr. </p>


### PR DESCRIPTION
Since we don't have episode-wise transcript credits yet, we could just link it to the list of episode transcripts on tumblr for now?
Also, I'm not sure exactly how we'd like to word that line, so feel free to change that as well.